### PR TITLE
Add HowTo page for configuring eduroam

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -15,6 +15,10 @@ h1#sexy-name {
     margin-bottom: 5%;
     display: inline-block;
 }
+#sexy-name a {
+    text-decoration: none;
+    color: black;
+}
 #github-star-container {
     margin-left: 5px;
     display: inline-block;

--- a/eduroam.html
+++ b/eduroam.html
@@ -25,6 +25,7 @@
             	</ul>
             	
             	<br>
+            	<br>
 
                 <h5>Further readings / References</h5>
                 <ul>

--- a/eduroam.html
+++ b/eduroam.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>tum.sexy | Configure eduroam Wifi</title>
+        <meta name="description" content="Tutorial on how to setup the eduroam wlan at the Technische Universität München">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+        <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
+        <link rel="stylesheet" href="css/normalize.css">
+        <link rel="stylesheet" href="css/skeleton.css">
+        <link rel="stylesheet" href="css/custom.css">
+        <link rel="icon" type="image/png" href="favicon.png" />
+    </head>
+    <body>
+        <div class="container">
+            <div class="row" id="header-row">
+                <h1 id="sexy-name"><a href="http://tum.sexy">TUM<strong>.sexy</strong></a> | eduroam config</h1>
+            </div>
+            <div class="row" style="margin-top:10%; text-align: center;">
+                <h3>How to configure your eduroam securely</h3>
+                <ul>
+                	<li>Don't setup your eduroam on Android manually, because it is <strong>not secure</strong>!</li>
+                	<li>Use the automatic setup of the <a href="http://app.tum.sexy">TUM Campus App</a> (recommended) or use a profile from <a href="https://cat.eduroam.de/">Eduroam CAT</a>.</li>
+                	<li>If configured wrongly, third parties are able to see your password in plaintext.</li>
+            	</ul>
+            	
+            	<br>
+
+                <h5>Further readings / References</h5>
+                <ul>
+                	<li><a href="https://www.dfn-cert.de/aktuell/Google-Android-Eduroam-Zugangsdaten.html">Bug description on DFN CERT</a></li>
+                	<li><a href="https://lists.lrz.de/pipermail/tum-it-newsletter/2016-February/000094.html">TUM-IT-Newsletter</a></li>
+                	<li><a href="https://www.lrz.de/services/netz/mobil/802_1x/android_en/">LRZ: eduroam with Android</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="footer">
+            <div class="right">
+                Provided by Lukas, <a href="https://bruck.me">Kordian</a> &amp; <a href="http://www.maxi-muth.de">Max</a>
+            </div>
+        </div>
+    </body>
+</html>

--- a/index.php
+++ b/index.php
@@ -59,6 +59,7 @@ $Router = new Route();
                         </li>
                         <li>FMI Bistro “Speiseplan” — <a href="http://hunger.tum.sexy">hunger.tum.sexy</a></li>
                         <li>MI Raumbelegungen — <a href="http://rooms.tum.sexy">rooms.tum.sexy</a></li>
+                        <li>HowTo: Configure eduroam securely - <a href="http://eduroam.tum.sexy">eduroam.tum.sexy</a></li>
                         <li><a href="https://sexipretschi.eu/Game/">Sexi Pretschi Game</a></li>
                         <li><a href="https://docs.google.com/document/d/1eW6DmvvKoolAWRMp6P3tMts-XWSb263Ap97LyRQ5Wno/edit?usp=sharing">Ersti Tipps</a></li>
                     </ul>

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -138,6 +138,10 @@ class Route {
         'app' => [
             'description' => 'TUM Campus App',
             'target' => 'https://tumcabe.in.tum.de/landing/'
+        ],
+        'eduroam' => [
+            'description' => 'HowTo: Setup eduroam securely!',
+            'target' => 'http://tum.sexy/eduroam.html'
         ]
     ];
 


### PR DESCRIPTION
<img width="1644" alt="screen shot 2017-03-13 at 16 02 08" src="https://cloud.githubusercontent.com/assets/3121306/23860332/e7434a48-0806-11e7-8906-62dc5e4b7d7d.png">


That's the moment where it sucks, that we have no proper template system set up with a base template that could be extended by pages like this 🙈 