### PR TITLE
Switch Mensa and IPP bistro positions

### DIFF
--- a/tpl/hunger.twig
+++ b/tpl/hunger.twig
@@ -12,12 +12,12 @@
     </div>
 
     <div class="one-half column">
-        {% include 'hunger_menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek} only %}
+        {% include 'hunger_menu.twig' with {'title': 'Mensa Garching', 'week': mensaWeek} only %}
     </div>
 </div>
 <div class="row" style="margin-top:10%">
     <div class="one-half column">
-        {% include 'hunger_menu.twig' with {'title': 'Mensa Garching', 'week': mensaWeek} only %}
+        {% include 'hunger_menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek} only %}
     </div>
 
     <div class="one-half column">


### PR DESCRIPTION
Mensa Garching is probably more important than the IPP bistro for most users, so let's show it next to the FMI Bistro to see it without scrolling on a laptop.