### PR TITLE
added moodle link support

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,3 @@
-
 #Turn on the magic
 RewriteEngine On
 
@@ -7,7 +6,5 @@ RewriteRule ^redirect - [L,NC]
 
 #Rewrite any subdomains to the correct script whichs checks where to forward to
 RewriteCond %{HTTP_HOST} !www.tum.sexy [NC]
-RewriteCond %{HTTP_HOST} ^(www\.)?([a-z0-9-]+).tum.sexy [NC]
-RewriteRule ^(.*)$ /redirect/index.php?sub=%2 [L]
-
-
+RewriteCond %{HTTP_HOST} ^(?:www\.)?(?:([a-z0-9-]+)\.)?([a-z0-9-]+).tum.sexy [NC]
+RewriteRule ^(.*)$ /redirect/index.php?sub=%3&subsub=%1 [L]

--- a/.htaccess
+++ b/.htaccess
@@ -7,4 +7,4 @@ RewriteRule ^redirect - [L,NC]
 #Rewrite any subdomains to the correct script whichs checks where to forward to
 RewriteCond %{HTTP_HOST} !www.tum.sexy [NC]
 RewriteCond %{HTTP_HOST} ^(?:www\.)?(?:([a-z0-9-]+)\.)?([a-z0-9-]+).tum.sexy [NC]
-RewriteRule ^(.*)$ /redirect/index.php?siteType=%3&redirectUrl=%1 [L]
+RewriteRule ^(.*)$ /redirect/index.php?redirectUrl=%3&siteType=%1 [L]

--- a/.htaccess
+++ b/.htaccess
@@ -7,4 +7,4 @@ RewriteRule ^redirect - [L,NC]
 #Rewrite any subdomains to the correct script whichs checks where to forward to
 RewriteCond %{HTTP_HOST} !www.tum.sexy [NC]
 RewriteCond %{HTTP_HOST} ^(?:www\.)?(?:([a-z0-9-]+)\.)?([a-z0-9-]+).tum.sexy [NC]
-RewriteRule ^(.*)$ /redirect/index.php?sub=%3&subsub=%1 [L]
+RewriteRule ^(.*)$ /redirect/index.php?siteType=%3&redirectUrl=%1 [L]

--- a/redirect/index.php
+++ b/redirect/index.php
@@ -2,5 +2,5 @@
 
 include __DIR__ . '/routes.php';
 $routeHandler = new Route();
-header('Location: ' . $routeHandler->getTargetOfSub(mb_strtolower($_GET['sub']), mb_strtolower($_GET['subsub']))); // Function does check if GET parameter is set / empty
+header('Location: ' . $routeHandler->getTargetOfSub(mb_strtolower($_GET['siteType']), mb_strtolower($_GET['redirectUrl']))); // Function does check if GET parameter is set / empty
 die();

--- a/redirect/index.php
+++ b/redirect/index.php
@@ -2,5 +2,5 @@
 
 include __DIR__ . '/routes.php';
 $routeHandler = new Route();
-header('Location: ' . $routeHandler->getTargetOfSub(mb_strtolower($_GET['sub']))); // Function does check if GET parameter is set / empty
+header('Location: ' . $routeHandler->getTargetOfSub(mb_strtolower($_GET['sub']), mb_strtolower($_GET['subsub']))); // Function does check if GET parameter is set / empty
 die();

--- a/redirect/index.php
+++ b/redirect/index.php
@@ -2,5 +2,5 @@
 
 include __DIR__ . '/routes.php';
 $routeHandler = new Route();
-header('Location: ' . $routeHandler->getTargetOfSub(mb_strtolower($_GET['siteType']), mb_strtolower($_GET['redirectUrl']))); // Function does check if GET parameter is set / empty
+header('Location: ' . $routeHandler->getTargetOfSub(mb_strtolower($_GET['redirectUrl']), mb_strtolower($_GET['siteType']))); // Function does check if GET parameter is set / empty
 die();

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -71,10 +71,12 @@ class Route {
         'anal'         => [
             'description' => 'Analysis für Informatiker',
             'target'      => 'https://www-m5.ma.tum.de/Allgemeines/MA0902_2017W',
+            'moodle_id'   => '36704',
         ],
         'info2'        => [
             'description' => 'Einführung in die Informatik 2',
             'target'      => 'https://www2.in.tum.de/hp/Main?nid=354',
+            'moodle_id'   => '35319',
         ],
         'e2ocaml'      => [
             'description' => 'Einführung in die Informatik 2 OCAML HA-Abgabe',
@@ -83,10 +85,12 @@ class Route {
         'db'           => [
             'description' => 'Grundlagen: Datenbanken',
             'target'      => 'https://db.in.tum.de/teaching/ws1718/grundlagen/',
+            'moodle_id'   => '38031',
         ],
         'gbs'          => [
             'description' => 'Grundlagen Betriebssystem und Systemsoftware',
             'target'      => 'https://www.sec.in.tum.de/i20/teaching/ws2017/grundlagen-betriebssysteme-und-systemsoftware',
+            'moodle_id'   => '35140',
         ],
         'quintero'     => [
             'description' => 'Mathias Quintero',
@@ -263,6 +267,7 @@ class Route {
     ];
 
     public function getTargetOfSub($subdomain) {
+        $key = 'target';
         if ($subdomain === 'json') {
             header('Content-type: application/json');
             die(json_encode($this->routes));
@@ -270,12 +275,21 @@ class Route {
         if (isset($this->synonyms[ $subdomain ])) {
             $subdomain = $this->synonyms[ $subdomain ];
         }
-
+        if (!isset($this->routes[ $subdomain ])) {
+            switch (substr($subdomain, 0, 1)) {
+                case 'x' :  
+                    $subdomain = 'https://www.moodle.tum.de/course/view.php?id=' . $this->substr($subdomain, 1);
+                    $key = 'moodle_id';
+                    break;
+                default: 
+                    break;
+            }
+        }
         if (!isset($this->routes[ $subdomain ])) {
             return 'http://tum.sexy/';
         }
 
-        return $this->routes[ $subdomain ]['target'];
+        return $this->routes[ $subdomain ][ $key ];
     }
 
     public function getResolvedArrays() {

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -266,34 +266,32 @@ class Route {
         ],
     ];
 
-    public function getTargetOfSub($subdomain, $subsub) {
+    public function getTargetOfSub($siteType, $redirectUrl=null) {
 
-        if ($subdomain === 'json') {
+        if ($siteType === 'json') {
             header('Content-type: application/json');
             die(json_encode($this->routes));
         }
 
-        if (isset($this->synonyms[ $subdomain ])) {
-            $subdomain = $this->synonyms[ $subdomain ];
+        if (isset($this->synonyms[ $siteType ])) {
+            $siteType = $this->synonyms[ $siteType ];
         }
 
-        switch ($subsub) {
+        switch ($redirectUrl) {
             case 'm' :  
                 // This is a moodle redirect like m.info1.tum.sexy
-                $moodle_id = $this->routes[ $subdomain ][ 'moodle_id' ];
+                $moodle_id = $this->routes[ $siteType ]['moodle_id'];
                 if (!isset($moodle_id)) {
-                    return $this->routes[ $subdomain ][ 'target' ];  // Fallback to target if moodle id is unknown
+                    return $this->routes[ $siteType ]['target'];  // Fallback to target if moodle id is unknown
                 }
                 return 'https://www.moodle.tum.de/course/view.php?id=' . $moodle_id;
-            default: 
-                break;
         }
 
-        if (!isset($this->routes[ $subdomain ])) {
+        if (!isset($this->routes[ $siteType ])) {
             return 'http://tum.sexy/';
         }
 
-        return $this->routes[ $subdomain ][ 'target' ];
+        return $this->routes[ $siteType ]['target'];
     }
 
     public function getResolvedArrays() {

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -266,30 +266,34 @@ class Route {
         ],
     ];
 
-    public function getTargetOfSub($subdomain) {
-        $key = 'target';
+    public function getTargetOfSub($subdomain, $subsub) {
+
         if ($subdomain === 'json') {
             header('Content-type: application/json');
             die(json_encode($this->routes));
         }
+
         if (isset($this->synonyms[ $subdomain ])) {
             $subdomain = $this->synonyms[ $subdomain ];
         }
-        if (!isset($this->routes[ $subdomain ])) {
-            switch (substr($subdomain, 0, 1)) {
-                case 'x' :  
-                    $subdomain = 'https://www.moodle.tum.de/course/view.php?id=' . $this->substr($subdomain, 1);
-                    $key = 'moodle_id';
-                    break;
-                default: 
-                    break;
-            }
+
+        switch ($subsub) {
+            case 'm' :  
+                // This is a moodle redirect like m.info1.tum.sexy
+                $moodle_id = $this->routes[ $subdomain ][ 'moodle_id' ];
+                if (!isset($moodle_id)) {
+                    return $this->routes[ $subdomain ][ 'target' ];  // Fallback to target if moodle id is unknown
+                }
+                return 'https://www.moodle.tum.de/course/view.php?id=' . $moodle_id;
+            default: 
+                break;
         }
+
         if (!isset($this->routes[ $subdomain ])) {
             return 'http://tum.sexy/';
         }
 
-        return $this->routes[ $subdomain ][ $key ];
+        return $this->routes[ $subdomain ][ 'target' ];
     }
 
     public function getResolvedArrays() {

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -71,6 +71,8 @@ class Route {
         'anal'         => [
             'description' => 'Analysis für Informatiker',
             'target'      => 'https://www-m5.ma.tum.de/Allgemeines/MA0902_2017W',
+             // If you change this moodle_id please also change in the MainTest.php, 
+             // since this url is also used for testing!
             'moodle_id'   => '36704',
         ],
         'info2'        => [

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -275,25 +275,25 @@ class Route {
             die(json_encode($this->routes));
         }
 
-        if (isset($this->synonyms[ $siteType ])) {
-            $siteType = $this->synonyms[ $siteType ];
+        if (isset($this->synonyms[$siteType])) {
+            $siteType = $this->synonyms[$siteType];
         }
 
         switch ($redirectUrl) {
             case 'm' :  
                 // This is a moodle redirect like m.info1.tum.sexy
-                $moodle_id = $this->routes[ $siteType ]['moodle_id'];
+                $moodle_id = $this->routes[$siteType]['moodle_id'];
                 if (!isset($moodle_id)) {
-                    return $this->routes[ $siteType ]['target'];  // Fallback to target if moodle id is unknown
+                    return $this->routes[$siteType]['target'];  // Fallback to target if moodle id is unknown
                 }
                 return 'https://www.moodle.tum.de/course/view.php?id=' . $moodle_id;
         }
 
-        if (!isset($this->routes[ $siteType ])) {
+        if (!isset($this->routes[$siteType])) {
             return 'http://tum.sexy/';
         }
 
-        return $this->routes[ $siteType ]['target'];
+        return $this->routes[$siteType]['target'];
     }
 
     public function getResolvedArrays() {
@@ -301,13 +301,13 @@ class Route {
 
         //Iterate over our sections which can contain any number of routes
         foreach ($this->sections as $section => $subs) {
-            $ret[ $section ] = [];
+            $ret[$section] = [];
 
             //Iterate over all routes in current section
             foreach ($subs as $sub) {
 
                 //Resolve the route and add to final array
-                $ret[ $section ][] = ['desc' => $this->routes[ $sub ]['description'], 'sub' => $sub];
+                $ret[$section][] = ['desc' => $this->routes[$sub]['description'], 'sub' => $sub];
             }
         }
 

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -5,7 +5,7 @@ class MainTest extends \PHPUnit\Framework\TestCase {
     public function testRouteResolving() {
         $router = new Route();
         // Normal redirect
-        $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger', null));
+        $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger'));
         // Subsubdomain redirect to moodle
         $this->assertContains('https://www.moodle.tum.de/course/view.php?id=36704', $router->getTargetOfSub('anal', 'm'));
     }

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -7,7 +7,7 @@ class MainTest extends \PHPUnit\Framework\TestCase {
         // Normal redirect
         $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger', null));
         // Subsubdomain redirect to moodle
-        $this->assertContains('https://www.moodle.tum.de/course/view.php?id=', $router->getTargetOfSub('anal', 'm'));
+        $this->assertContains('https://www.moodle.tum.de/course/view.php?id=36704', $router->getTargetOfSub('anal', 'm'));
     }
 
     public function testJsonOutput() {

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -4,7 +4,7 @@ class MainTest extends \PHPUnit\Framework\TestCase {
 
     public function testRouteResolving() {
         $router = new Route();
-        $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger'));
+        $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger', null));
     }
 
     public function testJsonOutput() {

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -7,7 +7,7 @@ class MainTest extends \PHPUnit\Framework\TestCase {
         // Normal redirect
         $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger', null));
         // Subsubdomain redirect to moodle
-        $this->assertContains('moodle.tum.de', $router->getTargetOfSub('anal', 'm'));
+        $this->assertContains('https://www.moodle.tum.de/course/view.php?id=', $router->getTargetOfSub('anal', 'm'));
     }
 
     public function testJsonOutput() {

--- a/tests/General/MainTest.php
+++ b/tests/General/MainTest.php
@@ -4,7 +4,10 @@ class MainTest extends \PHPUnit\Framework\TestCase {
 
     public function testRouteResolving() {
         $router = new Route();
+        // Normal redirect
         $this->assertEquals('http://tum.sexy/hunger', $router->getTargetOfSub('hunger', null));
+        // Subsubdomain redirect to moodle
+        $this->assertContains('moodle.tum.de', $router->getTargetOfSub('anal', 'm'));
     }
 
     public function testJsonOutput() {


### PR DESCRIPTION
Shortcuts for moodle links
Every course has its own id, that is saved in the routes array.
Prepend an x before the shortcut and you get redirected to the moodle site.
e.g. xinfo2.tum.sexy 
I added ids for the 3. semester.

Used a switch statement for other sites that have a similar behavior, that might come in the future.

Using x as an prefix is just an suggestion, m might fit better but then you might get some collisions.

I have not tested this, since I don't really know php, but should be fine.

Huge thank you for creating this site!