### PR TITLE
Added route for WZW-Garching shuttle bus

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -225,6 +225,10 @@ class Route {
         'satellite'          => [
             'description' => 'The TUM Satellite',
             'target'      => 'https://www.move2space.de/',
+        ],
+        'shuttle'          => [
+            'description' => 'Wochenfahrpläne Shuttlebus WZW-GAR-MUC',
+            'target'      => 'http://wzw.tum.de/index.php?id=416',
         ]
 
     ];

--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -262,7 +262,7 @@ class Route {
         ],
         '6. Semester' => [],
         'Special'     => [
-            'hunger', 'mensabot', 'mensabot2', 'roombot', 'rooms', 'app', 'c', 'm', 'sp', 'ma-sp', 'wi-sp', 'wi-ma-sp', 'stuff', 'reddit', 'vorkurs',
+            'hunger', 'mensabot', 'mensabot2', 'roombot', 'rooms', 'app', 'c', 'm', 'shuttle', 'sp', 'ma-sp', 'wi-sp', 'wi-ma-sp', 'stuff', 'reddit', 'vorkurs',
         ],
         'Electives'   => [
             'pl', 'gki', 'conpra', 'ged', 'pgm', 'gog', 'artemis', 'csc', 'scivis', 'ase', 'qo', 'netsec'


### PR DESCRIPTION
Hi, 
I've added the route for the WZW<<>>Garching shuttle bus. I've also added it to the sections in the 'Specials' category.

It's linked to the page where the "Wissenschaftszentrum Weihenstephan für Ernährung, Landnutzung und Umwelt" (WZW) is uploading the bus schedules for the active and the coming week.
The shuttle is organized by this faculty and is used by members of various bachelor and master courses including biochemistry, molecular biotechnology, biology, industrial biotech., food chemistry, bioprocess technology, brewing and some more.


We would be happy having a short link for this. 
Thanks for providing this service!