### PR TITLE
Always show next five days in Hunger.

### DIFF
--- a/hunger/index.php
+++ b/hunger/index.php
@@ -5,6 +5,7 @@ include __DIR__ . '/../setup.php';
 use JPBernius\FMeat\FMeatClient;
 use JPBernius\FMeat\Configurations\Locations;
 use JPBernius\FMeat\Exeptions\{NetworkingException, DayNotFoundException};
+use JPBernius\FMeat\Entities\Day;
 
 $fmeat = new FMeatClient(true);
 
@@ -18,13 +19,21 @@ $locations = [
 $output = [];
 foreach ($locations as $viewKey => $apiName) {
     try {
-        $output[$viewKey] = $fmeat->getCurrentWeekForLocation($apiName);
-        if($output[$viewKey]->getDay(5)->getDate()->format("Y-m-d") < date("Y-m-d")) {
-            $output[$viewKey] = $fmeat->getNextWeekForLocation($apiName);
-        }
+        $thisWeek = iterator_to_array($fmeat->getCurrentWeekForLocation($apiName));
+        $thisWeek = array_filter($thisWeek, function (Day $day) {
+            return $day->getDate() > new DateTime('today midnight');
+        });
     } catch (NetworkingException|DayNotFoundException $e) {
-        $output[$viewKey] = null;
+        $thisWeek = [];
     }
+
+    try {
+        $nextWeek = iterator_to_array($fmeat->getNextWeekForLocation($apiName));
+    } catch (NetworkingException|DayNotFoundException $e) {
+        $nextWeek = [];
+    }
+
+    $output[$viewKey] = array_merge($thisWeek, $nextWeek);
 }
 
 //Render the template

--- a/tpl/hunger_menu.twig
+++ b/tpl/hunger_menu.twig
@@ -3,16 +3,14 @@
 {% if week == null %}
     <p>An error occured while fetching the {{ title }} menu.</p>
 {% else %}
-    {% for day in week %}
-        {% if  day.getDate() | date('Y-m-d') >= "now" | date('Y-m-d') %}
-            <strong>{{day.getDate() | date("l, F j")}}<sup>{{day.getDate() | date("S")}}</sup></strong>
-            <ul class="hunger-menu">
-            {% for dish in day %}
-                <li data-balloon="{{ dish.getPrice() | number_format(2, '.', ',') }} €" data-balloon-pos="up" onclick="void(0)">
-                    {{ dish.getName() }}
-                </li>
-            {% endfor %}
-            </ul>
-        {% endif %}
+    {% for day in week[:5] %}
+        <strong>{{day.getDate() | date("l, F j")}}<sup>{{day.getDate() | date("S")}}</sup></strong>
+        <ul class="hunger-menu">
+        {% for dish in day %}
+            <li data-balloon="{{ dish.getPrice() | number_format(2, '.', ',') }} €" data-balloon-pos="up" onclick="void(0)">
+                {{ dish.getName() }}
+            </li>
+        {% endfor %}
+        </ul>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
This changes the behaviour of **Hunger** to show the next 5 days if possible.
So this means for example on Wednesday it will show:
1. Wednesday
2. Thursday
3. Friday
4. Monday (next week)
5. Tuesday (next week)

The number of `5` is chosen to keep the number of days in advance compact enough.

![image](https://user-images.githubusercontent.com/6382716/41156160-013da5be-6b21-11e8-9fb3-999048c45b91.png)
