### PR TITLE
Updated redirect for info1

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -111,7 +111,7 @@ class Route {
         ],
         'info1'        => [
             'description' => 'Einführung in die Informatik 1',
-            'target'      => 'http://www14.in.tum.de/lehre/2017WS/info1/index.html.de',
+            'target'      => 'https://www.moodle.tum.de/course/view.php?id=42050',
         ],
         'pgdp'         => [
             'description' => 'Praktikum Grundlagen der Programmierung (Moodle-Kurs)',


### PR DESCRIPTION
updated redirect for "Einführung in die Informatik 1", this term info1 and pgdp don't use separated pages but rather use the same Moodle page, thus info1.tum.sexy and pgdp.tum.sexy will now redirect to the same page.
Maybe merge "Einführung in die Informatik" and "Praktikum: Grundlagen der Programmierung" on link page into one entry, new redirect prefix needed? or keep both info1 and pgdp to redirect to the same page?