### PR TITLE
add fallback url in hunger/menu.twig

### DIFF
--- a/tpl/hunger/hunger.twig
+++ b/tpl/hunger/hunger.twig
@@ -8,20 +8,20 @@
 
 <div class="row" style="margin-top:10%">
     <div class="one-half column">
-        {% include 'hunger/menu.twig' with {'title': 'FMI Bistro', 'week': fmiBistroWeek} only %}
+        {% include 'hunger/menu.twig' with {'title': 'FMI Bistro', 'week': fmiBistroWeek, 'fallback_url': 'https://www.wilhelm-gastronomie.de/tum-garching'} only %}
     </div>
 
     <div class="one-half column">
-        {% include 'hunger/menu.twig' with {'title': 'Mensa Garching', 'week': mensaWeek} only %}
+        {% include 'hunger/menu.twig' with {'title': 'Mensa Garching', 'week': mensaWeek, 'fallback_url': 'https://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_422_-de.html#heute'} only %}
     </div>
 </div>
 <div class="row" style="margin-top:10%">
     <div class="one-half column">
-        {% include 'hunger/menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek} only %}
+        {% include 'hunger/menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek, 'fallback_url': 'https://konradhof-catering.de/ipp/'} only %}
     </div>
 
     <div class="one-half column">
-        {% include 'hunger/menu.twig' with {'title': 'StuCafé Mechanical Engineering', 'week': stucafeMaschbauWeek} only %}
+        {% include 'hunger/menu.twig' with {'title': 'StuCafé Mechanical Engineering', 'week': stucafeMaschbauWeek, 'fallback_url': 'https://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_527_-de.html#heute'} only %}
     </div>
 </div>
 <div class="row" style="margin-top:10%">

--- a/tpl/hunger/menu.twig
+++ b/tpl/hunger/menu.twig
@@ -2,7 +2,7 @@
 
 {% if week == null %}
     <p>An error occured while fetching the {{ title }} menu.<br />
-    <a href="https://www.wilhelm-gastronomie.de/tum-garching">Menu by bistro owner (PDF)</a></p>
+    <a href="{{ fallback_url }}">Menu by bistro owner (PDF)</a></p>
 {% else %}
     {% for day in week[:5] %}
         <strong>{{day.getDate() | date("l, F j")}}<sup>{{day.getDate() | date("S")}}</sup></strong>


### PR DESCRIPTION
Currently the IPP bistro fails and as a fallback the MI bistro's pdf link was displayed. I added a `fallback_url` field and added URLs for all bistros.