### PR TITLE
Update for new tumi calender

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -324,7 +324,7 @@ class Route {
         ],
         'esn'          => [
             'description' => 'ESN TUMi München',
-            'target'      => 'https://portal.mytum.de/veranstaltungen/ic/termine-tumi/index_html',
+            'target'      => 'https://esn-tumi.de',
         ],
         'adm'          => [
             'description' => 'Algorithmische Diskrete Mathematik',
@@ -455,6 +455,7 @@ class Route {
         'urban-mobility'=> 'ecarus',
         'kino'    => 'film',
         'gdb'     => 'db',
+	'tumi'    => 'esn',
         'complexity' => 'comp',
 		'sp-ge' => 'ge-sp'
     ];


### PR DESCRIPTION
Please do not merge (yet)
TUMi is soon switching the calendar over to this domain and I feel like `tumi` should also be a valid route
I'll update this PR once the switch is complete, current schedule is set for the next semester