### PR TITLE
Add route restplaetze, related to seminar matching

### DIFF
--- a/redirect/routes.php
+++ b/redirect/routes.php
@@ -429,6 +429,10 @@ class Route {
             'description' => 'TUM4Future',
             'target'      => 'https://tum4future.de',
         ],
+        'restplaetze'     => [
+            'description' => 'Liste der Restplätze in Seminaren und Praktika',
+            'target'      => 'https://www.in.tum.de/fuer-studierende/module-und-veranstaltungen/praktika-und-seminare/',
+        ],
     ];
 
     // Format is: <source / synonym> => <target> - the target must be present in the $routes array


### PR DESCRIPTION
Die Informatik-Fakultät stellt eine Liste mit Restplätzen in Seminaren und
Praktika bereit für diejenigen, die im Matching kein Glück hatten oder das
Matching vergessen haben. Nachdem ich bereits mehrmals nach dieser Liste
gefragt wurde, nun ein Shortlink dafür.