### PR TITLE
Add support for dark mode

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -38,7 +38,6 @@ a.logo {
     position: relative !important;
     opacity: 0.9;
     padding: 0 20px 20px 20px;
-    background-color: rgba(255, 255, 255, 0.8);
 }
 
 ul.hunger-menu {
@@ -144,3 +143,77 @@ div.padding {
     padding: 6px 15px 6px 0;
     text-align: right;
 }
+
+.section-header {
+    margin-left: 1%;
+    margin-right: 1%;
+}
+.semester>li {
+    list-style-type: none;
+    border-bottom: 1px solid #dedede;
+    margin: 0;
+    padding: 1rem 1rem 1rem 1rem;
+    position: relative;
+    left: -1rem;
+}
+.semester>li:last-child {
+    margin-bottom: 3rem;
+}
+.semester>li:hover {
+    background-color: #f6f6f6;
+}
+
+h3 {
+    font-weight: 300;
+    font-size: 2.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #222;
+    text-transform: uppercase;
+    letter-spacing: 5px;
+}
+
+h4 {
+    font-size: 1.8rem;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    font-weight: 700;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #0b0c10;
+        color: #e5e6e7;
+    }
+    #searchbox {
+        color: #e5e6e7;
+        background-color: #1f2833;
+        border-color: #45a29e; 
+    }
+    #searchbox:focus {
+        border-color: #66fcf1; 
+    }
+    h3 {
+        border-bottom-color: #888;
+    }
+    .semester>li {
+        border-color: #45a29e;
+    }
+    .semester>li:hover {
+        background-color: #1f2833;
+    }
+    mark {
+        background-color: #66fcf1;
+    }
+    #sexy-name {
+        color: #fff;
+    }
+    a, a:link, a:visited {
+        color: #66fcf1;
+    }
+    a:hover, a:active, a:focus {
+        color: #ccfffc;
+    }
+    img {
+        filter: grayscale(30%);
+    }
+  }

--- a/css/custom.css
+++ b/css/custom.css
@@ -216,4 +216,17 @@ h4 {
     img {
         filter: grayscale(30%);
     }
-  }
+    [data-balloon]::after {
+            background-color: rgba(31, 40, 51, 0.8);
+            border: 1px solid #66fcf1;
+            border-bottom: 0px;
+            border-radius: 0px;
+            font-weight: 500;
+            color: #e5e6e7;
+    }
+    [data-balloon-pos="up"]::before {
+        background:no-repeat url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2236px%22%20height%3D%2212px%22%3E%3Cpath%20fill%3D%22rgba(31%2C%2040%2C%2051%2C%200.8)%22%20stroke%3D%22%2366fc141%22%20stroke-width%3D%221%22%20transform%3D%22rotate(0)%22%20d%3D%22M2.658%2C0.000%20C-13.615%2C0.000%2050.938%2C0.000%2034.662%2C0.000%20C28.662%2C0.000%2023.035%2C12.002%2018.660%2C12.002%20C14.285%2C12.002%208.594%2C0.000%202.658%2C0.000%20Z%22%2F%3E%3C%2Fsvg%3E");
+        background-size:100% auto;
+        color: #e5e6e7;
+    }
+}

--- a/css/custom.css
+++ b/css/custom.css
@@ -38,12 +38,7 @@ a.logo {
     position: relative !important;
     opacity: 0.9;
     padding: 0 20px 20px 20px;
-}
-
-ul.hunger-menu {
-    margin-left: 1em;
-    list-style-position: outside;
-}
+} 
 
 #footer {
     position: fixed;
@@ -158,6 +153,63 @@ div.padding {
     display: block;
 }
 
+.hunger-block {
+    padding: 0 1rem;
+}
+
+.hunger-block h5 {
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+    margin: 3rem 0 0.5rem 0;
+}
+
+ul.hunger-menu>li {
+    list-style-type: none;
+    border-bottom: 1px solid #dedede;
+    margin: 0;
+    padding: 1rem 1rem 1rem 1rem;
+    position: relative;
+    left: -1rem;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+ul.hunger-menu>li:last-child {
+    border-bottom: none;
+}
+ul.hunger-menu>li:hover {
+    background-color: #f6f6f6;
+}
+
+ul.hunger-menu .item-special::after {
+    content: "S";
+    display: inline-block;
+    border-radius: 10%;
+    background-color: #1EAEDB;
+    color: #fff;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    margin-right: 1rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+}
+ul.hunger-menu .item-title {
+    margin-right: auto;
+}
+
+ul.hunger-menu .item-price {
+    display: block;
+    color: #1EAEDB;
+    white-space: nowrap;
+    margin-left: 0.75rem;
+    justify-self: end;
+    text-align: center;
+}
+
 .semester>li {
     list-style-type: none;
     border-bottom: 1px solid #dedede;
@@ -166,6 +218,7 @@ div.padding {
     position: relative;
 }
 .semester>li:last-child {
+    border-bottom: none;
     margin-bottom: 3rem;
 }
 .semester>li:hover {
@@ -173,6 +226,10 @@ div.padding {
 }
 .semester>h4 {
     padding: 0 1rem;
+}
+
+h1 > sup, h2 > sup, h3 > sup, h4 > sup, h5 > sup {
+    text-transform: none;
 }
 
 h3 {
@@ -209,6 +266,12 @@ h4 {
     }
 }
 
+@media (min-width: 850px) {
+    ul.hunger-menu .item-special::after {
+        content: 'Special';
+    }
+}
+
 @media (prefers-color-scheme: dark) {
     body {
         background-color: #0b0c10;
@@ -224,6 +287,20 @@ h4 {
     }
     h3 {
         border-bottom-color: #888;
+    }
+    ul.hunger-menu>li {
+        border-color: #45a29e;
+    }
+    ul.hunger-menu>li:hover {
+        background-color: #1f2833;
+    }
+    ul.hunger-menu>li>span.item-price {
+        color: #66fcf1;
+    }
+    ul.hunger-menu .item-special::after {
+        border: 1px solid #66fcf1;
+        background-color: rgba(0,0,0,0);
+        color: #e5e6e7;
     }
     .semester>li {
         border-color: #45a29e;

--- a/css/custom.css
+++ b/css/custom.css
@@ -191,10 +191,17 @@ h4 {
     font-weight: 700;
 }
 
+.subsection {
+    padding: 0 1rem;
+}
+
 @media (min-width: 550px) {
     .section-header {
         margin: 0 1%;
         padding: 0 1rem;
+    }
+    .subsection {
+        padding: 0 2%;
     }
     #searchbox-wrapper {
         margin: 0 1rem;

--- a/css/custom.css
+++ b/css/custom.css
@@ -145,22 +145,34 @@ div.padding {
 }
 
 .section-header {
-    margin-left: 1%;
-    margin-right: 1%;
+    margin: 0 1rem;
 }
+
+#searchbox {
+    box-sizing: border-box;
+    height: 48px;
+    width: 100%;
+}
+#searchbox-wrapper {
+    margin: 0 1rem;
+    display: block;
+}
+
 .semester>li {
     list-style-type: none;
     border-bottom: 1px solid #dedede;
     margin: 0;
     padding: 1rem 1rem 1rem 1rem;
     position: relative;
-    left: -1rem;
 }
 .semester>li:last-child {
     margin-bottom: 3rem;
 }
 .semester>li:hover {
     background-color: #f6f6f6;
+}
+.semester>h4 {
+    padding: 0 1rem;
 }
 
 h3 {
@@ -177,6 +189,17 @@ h4 {
     text-transform: uppercase;
     letter-spacing: 3px;
     font-weight: 700;
+}
+
+@media (min-width: 550px) {
+    .section-header {
+        margin: 0 1%;
+        padding: 0 1rem;
+    }
+    #searchbox-wrapper {
+        margin: 0 1rem;
+        padding: 0 2%;
+    }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/tpl/head.twig
+++ b/tpl/head.twig
@@ -5,7 +5,7 @@
 <meta name="description" content="Helpful links, subdomains, redirects and tools for students of the Technical University Munich (TUM)">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link href='https://fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Raleway:400,300,600,700' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" href="/css/normalize.css">
 <link rel="stylesheet" href="/css/skeleton.css">
 <link rel="stylesheet" href="/css/balloon.min.css">

--- a/tpl/hunger/hunger.twig
+++ b/tpl/hunger/hunger.twig
@@ -3,11 +3,11 @@
 </div>
 
 
-<p>This is the 'Speiseplan' of the current week in the FMI Bistro of the Informatik Fakultät at TUM, the Mensa
-    Garching and other eating occasions at the campus Garching.</p>
+<div class="section-header">This is the 'Speiseplan' of the current week in the FMI Bistro of the Department of Informatics at TUM, the Mensa
+    Garching and other eating occasions at the campus Garching.</div>
 
 <div class="row" style="margin-top:10%">
-    <div class="one-half column">
+    <div class="one-half column hunger-block">
         {% include 'hunger/menu.twig' with {
             'title': 'FMI Bistro',
             'week': fmiBistroWeek,
@@ -19,25 +19,25 @@
         } only %}
     </div>
 
-    <div class="one-half column">
+    <div class="one-half column hunger-block">
         {% include 'hunger/menu.twig' with {'title': 'Mensa Garching', 'week': mensaWeek, 'fallback_url': 'https://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_422_-de.html#heute'} only %}
     </div>
 </div>
 <div class="row" style="margin-top:10%">
-    <div class="one-half column">
+    <div class="one-half column hunger-block">
         {% include 'hunger/menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek, 'fallback_url': 'https://konradhof-catering.de/ipp/'} only %}
     </div>
 
-    <div class="one-half column">
+    <div class="one-half column hunger-block">
         {% include 'hunger/menu.twig' with {'title': 'StuCafé Mechanical Engineering', 'week': stucafeMaschbauWeek, 'fallback_url': 'https://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_527_-de.html#heute'} only %}
     </div>
 </div>
 <div class="row" style="margin-top:10%">
-    <div class="one-half column">
+    <div class="one-half column hunger-block">
         {% include 'hunger/pita_booth.twig' %}
     </div>
 
-    <div class="one-half column">
+    <div class="one-half column hunger-block">
         {% include 'hunger/mi_geniessbar.twig' %}
     </div>
 </div>

--- a/tpl/hunger/menu.twig
+++ b/tpl/hunger/menu.twig
@@ -5,19 +5,22 @@
         <a href="{{ fallback_url }}">Menu by bistro owner (PDF)</a></p>
 {% else %}
     {% for day in week[:5] %}
-        <strong>{{ day.getDate() | date("l, F j") }}<sup>{{ day.getDate() | date("S") }}</sup></strong>
+
+        <h5>{{ day.getDate() | date("l, F j") }}<sup>{{ day.getDate() | date("S") }}</sup></h5>
         <ul class="hunger-menu">
             {% for dish in day %}
-                <li data-balloon="{{ dish.getPrice() | number_format(2, '.', ',') }} €" data-balloon-pos="up"
+                <li 
                     onclick="void(0)">
-                    {{ dish.getName() }}
+                    <span class="item-title">{{ dish.getName() }}</span>
+                    <span class="item-price">{{ dish.getPrice() | number_format(2, '.', ',') }}€</span>
                 </li>
             {% endfor %}
             {% if fixed_dishes != null and fixed_dishes[loop.index0] != null %}
                 {% for dish in fixed_dishes[loop.index0] %}
-                    <li data-balloon="{{ dish.price | number_format(2, '.', ',') }} €" data-balloon-pos="up"
-                        onclick="void(0)">
-                        <i>Special</i> {{ dish.name }}
+                    <li onclick="void(0)">
+                        <span class="item-special"></span>
+                        <span class="item-title">{{ dish.getName() }}</span>
+                        <span class="item-price">{{ dish.getPrice() | number_format(2, '.', ',') }} €</span>
                     </li>
                 {% endfor %}
             {% endif %}

--- a/tpl/hunger/mi_geniessbar.twig
+++ b/tpl/hunger/mi_geniessbar.twig
@@ -1,15 +1,17 @@
 <h3>FMI geniessBar</h3>
 
-<strong>Monday</strong>
+<h5>Monday</h5>
 <ul class="hunger-menu">
-    <li data-balloon="3.70 €" data-balloon-pos="up" onclick="void(0)">
-        XXL Hot Dogs in der Semmel mit Gurken & Zwiebeln
+    <li onclick="void(0)">
+        <span class="item-title">XXL Hot Dogs in der Semmel mit Gurken &amp; Zwiebeln</span>
+        <span class="item-price">3.70 €</span>
     </li>
 </ul>
 
-<strong>Tuesday</strong>
+<h5>Tuesday</h5>
 <ul class="hunger-menu">
-    <li data-balloon="4.50 €" data-balloon-pos="up" onclick="void(0)">
-        Mie Nudeln mit wechselnder Einlage im to go Becher
+    <li onclick="void(0)">
+        <span class="item-title">Mie Nudeln mit wechselnder Einlage im to go Becher</span>
+        <span class="item-price">4.50€</span>
     </li>
 </ul>

--- a/tpl/hunger/pita_booth.twig
+++ b/tpl/hunger/pita_booth.twig
@@ -1,6 +1,14 @@
 <h3>Pita Booth at ESO parking lot</h3>
-<strong>Tuesdays, Wednesdays, Thursdays</strong>
-<br> 11:00h - 14:00h
-<br> Offers
-<strong data-balloon="4.50 - 5.50 €" data-balloon-pos="up" onclick="void(0)">pita bread</strong> with different fillings and some small desert.
-<br> Additionally wednesdays pasta is available.
+<h5>Tuesday, Wednesday, Thursday<br>11:00h - 14:00h</h5>
+<ul class="hunger-menu">
+<li onclick="void(0)">
+<span class="item-title">Pita bread with different fillings and some small desert</span>
+<span class="item-price">4.50€<br>&ndash; 5.50€</span>
+</li>
+</ul>
+<h5>Wednesday</h5>
+<ul class="hunger-menu">
+<li>
+<span class="item-title">Great variety of different pasta</span>
+</li>
+</ul>

--- a/tpl/start.twig
+++ b/tpl/start.twig
@@ -5,7 +5,7 @@
            data-count-api="/repos/mammuth/TUM.sexy#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star mammuth/TUM.sexy on GitHub">Star</a>
     </div>
 </div>
-<input type="text" id="searchbox" placeholder="Search"/>
+<span id="searchbox-wrapper"><input type="text" id="searchbox" placeholder="Search"/></span>
 <main id="main">
     <div class="row" style="margin-top:10%">
         <div class="twelve column">
@@ -34,7 +34,7 @@
         </div>
     </div>
     <div class="row" style="margin-top:10%">
-        <div class="one-half column">
+        <div class="one-half column subsection">
             <h3>About</h3>
             <ul>
                 <li>If you want to <strong>update or add redirects</strong>, take a look at the instructions on the <a href="https://github.com/mammuth/TUM.sexy/tree/master/redirect" target="_blank">Github
@@ -61,7 +61,7 @@
                 </form>
             </div> #}
         </div>
-        <div class="one-half column">
+        <div class="one-half column subsection">
             <h3>Projects / Links</h3>
             <ul>
                 <li><a href="https://cal.bruck.me">Calendar Proxy</a>

--- a/tpl/start.twig
+++ b/tpl/start.twig
@@ -9,20 +9,20 @@
 <main id="main">
     <div class="row" style="margin-top:10%">
         <div class="twelve column">
-            <div>
+            <div class="section-header">
                 <h3 data-ss-nofilter>Redirects</h3>
                 <p data-ss-nofilter>
-                    No need for remembering long and ugly urls or bookmarks— Just use these redirects!
+                    No need for remembering long and ugly urls or bookmarks &ndash; Just use these redirects!
                 </p>
             </div>
 
             <div class="row">
                     {% for section,elements in routes %}
                         {% if loop.index % 2 == 0 %}
-                            </div><div class="one-half column" data-ss-forceadditional="{{ section }}">
+                            </div><div class="one-half column semester" data-ss-forceadditional="{{ section }}">
                         {% endif %}
                         {% if loop.index % 2 == 1 %}
-                            {% if loop.index != 1 %}</div>{%endif%}<div class="one-half column" data-ss-forceadditional="{{ section }}">
+                            {% if loop.index != 1 %}</div>{%endif%}<div class="one-half column semester" data-ss-forceadditional="{{ section }}">
                         {% endif %}
                         <h4>{{ section }}</h4>
                         {% for route in elements %}


### PR DESCRIPTION
This pull request adds support for dark mode using `prefers-color-scheme` and improves the format of link lists and headers. [Since a lot of newer browser versions](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) support the `prefers-color-scheme` property, this seems to be the best way to go.

Of course, design and color schemes depends a lot on personal taste so please give feedback!

### Preview

<img width="2560" alt="tumsexy-redesign-overview" src="https://user-images.githubusercontent.com/3391295/68960148-7faaae80-07c7-11ea-9516-67861a9e6270.png">
