### PR TITLE
Fix IPP URL

### DIFF
--- a/tpl/hunger/hunger.twig
+++ b/tpl/hunger/hunger.twig
@@ -28,7 +28,7 @@
 </div>
 <div class="row" style="margin-top:10%">
     <div class="one-half column hunger-block">
-        {% include 'hunger/menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek, 'fallback_url': 'https://konradhof-catering.de/ipp/'} only %}
+        {% include 'hunger/menu.twig' with {'title': 'IPP Bistro', 'week': ippBistroWeek, 'fallback_url': 'https://konradhof-catering.com/ipp/'} only %}
     </div>
 
     <div class="one-half column hunger-block">


### PR DESCRIPTION
IPP canteen URL has been moved to .com instead of .de. This seems to be permanent